### PR TITLE
Implement binary (B and BS) unwraping

### DIFF
--- a/lib/AttributeValue.js
+++ b/lib/AttributeValue.js
@@ -128,8 +128,16 @@ var _wrap1 = (function wrapping(){
 var _unwrap1 = (function unwrapping(){
 
   var funcs = {
-    "B": undefined,
-    "BS": undefined,
+    "B": function(str){
+      var buff = new Buffer(str.length);
+      for (var i=0; i<str.length; i++) {
+        buff[i] === str.charCodeAt(i);
+      }
+      return buff
+    },
+    "BS": function(strs){
+      return strs.map(funcs.B);
+    },
     "N": function (o) {return Number(o);},
     "NS":function (arr) {return arr.map(function(o) {return Number(o);});},
     "S": undefined,


### PR DESCRIPTION
This is horribly undocumented, but if you e.g. do `String(new Buffer([97, 98, 99]))` you get "abc".  

`String(buffer)` does `[CharCode] -> String`, so to reverse it you need to do `String -> [CharCode]`.
