### PR TITLE
Add Map datatype unwarp

### DIFF
--- a/lib/AttributeValue.js
+++ b/lib/AttributeValue.js
@@ -133,7 +133,8 @@ var _unwrap1 = (function unwrapping(){
     "N": function (o) {return Number(o);},
     "NS":function (arr) {return arr.map(function(o) {return Number(o);});},
     "S": undefined,
-    "SS": undefined
+    "SS": undefined,
+    "M": function (val) { return unwrap(val) }
   };
 
   var types = Object.keys(funcs);


### PR DESCRIPTION
Adding unwrap functionality to MAP data type. This is done by calling the unwrap function again with the map value.Please note that MAP data type is supported for unwrap only.