### PR TITLE
Fix Issue #7

### DIFF
--- a/lib/AttributeValue.js
+++ b/lib/AttributeValue.js
@@ -47,7 +47,17 @@ function detectType(val) {
   }
 
   if (isstring(val))
-    return 'S';
+  {
+    // in Dynamo strings cannot be empty
+    if (val.length > 0)
+    {
+      return 'S';
+    }
+    else
+    {
+      return 'NULL';
+    }
+  }
 
   if (isnumber(val))
     return 'N';

--- a/tests/spec/AttributeValue.mockdata.js
+++ b/tests/spec/AttributeValue.mockdata.js
@@ -103,15 +103,21 @@ module.exports = {
     1.4,
     'str single',
     [1, 2, 3.1],
-    ['str1', 'str2', 'str3'],
-    '' // dynamo won't accept empty strings so we wrap as null
+    ['str1', 'str2', 'str3']
   ],
 
   singles_: [
     { N: '1.4' },
     { S: 'str single' },
     { NS: [ '1', '2', '3.1' ] },
-    { SS: [ 'str1', 'str2', 'str3' ] },
+    { SS: [ 'str1', 'str2', 'str3' ] }
+  ],
+
+  illegalValues: [
+    '' // dynamo won't accept empty strings so we wrap as null
+  ],
+
+  illegalValues_: [
     { NULL: true }
   ]
 

--- a/tests/spec/AttributeValue.mockdata.js
+++ b/tests/spec/AttributeValue.mockdata.js
@@ -103,14 +103,16 @@ module.exports = {
     1.4,
     'str single',
     [1, 2, 3.1],
-    ['str1', 'str2', 'str3']
+    ['str1', 'str2', 'str3'],
+    '' // dynamo won't accept empty strings so we wrap as null
   ],
 
   singles_: [
     { N: '1.4' },
     { S: 'str single' },
     { NS: [ '1', '2', '3.1' ] },
-    { SS: [ 'str1', 'str2', 'str3' ] }
+    { SS: [ 'str1', 'str2', 'str3' ] },
+    { NULL: true }
   ]
 
 };

--- a/tests/spec/AttributeValue.spec.js
+++ b/tests/spec/AttributeValue.spec.js
@@ -13,6 +13,8 @@ describe("AttributeValue", function() {
   var objInvalid_ = mock.objInvalid_;
   var singles = mock.singles;
   var singles_ = mock.singles_;
+  var illegalValues = mock.illegalValues;
+  var illegalValues_ = mock.illegalValues_;
 
   // for (var i = 0; i < singles.length; i++)
   //   console.log(util.wrap1(singles[i]));
@@ -38,6 +40,11 @@ describe("AttributeValue", function() {
   it("Wrap singles", function() {
     for (var i = 0; i < singles.length; i++)
       expect(_.isEqual(util.wrap1(singles[i]), singles_[i])).toBe(true);
+  });
+
+  it("Wrap values outside AWS spec", function() {
+    for (var i = 0; i < illegalValues.length; i++)
+      expect(_.isEqual(util.wrap1(illegalValues[i]), illegalValues_[i])).toBe(true);
   });
 
   it("Wrap String object", function() {

--- a/tests/spec/AttributeValue.spec.js
+++ b/tests/spec/AttributeValue.spec.js
@@ -34,6 +34,7 @@ describe("AttributeValue", function() {
     var binWrap = util.wrap(obj3).bin.B;
     expect(bufferEqual(binWrap, obj3_.bin.B)).toBe(true);
   });
+
   it("Wrap singles", function() {
     for (var i = 0; i < singles.length; i++)
       expect(_.isEqual(util.wrap1(singles[i]), singles_[i])).toBe(true);


### PR DESCRIPTION
Dynamo API doesn't allow zero length strings. This library discovers that a parameter is a string so seems the correct place to handle storing empty strings as nulls.