### PR TITLE
Implement unwrap for lower-case type strings

### DIFF
--- a/lib/AttributeValue.js
+++ b/lib/AttributeValue.js
@@ -168,10 +168,11 @@ function unwrap1(dynamoData) {
   if (keys.length !== 1)
     throw new Error('Unexpected DynamoDB AttributeValue');
   var typeStr = keys[0];
-  if (!unwrapFns.hasOwnProperty(typeStr))
+  var typeStrUpperCase = typeStr.toUpperCase();
+  if (!unwrapFns.hasOwnProperty(typeStrUpperCase))
     throw errs.NoDatatype;
   var val = dynamoData[typeStr];
-  return unwrapFns[typeStr] ? unwrapFns[typeStr](val) : val;
+  return unwrapFns[typeStrUpperCase] ? unwrapFns[typeStrUpperCase](val) : val;
 }
 
 /**

--- a/tests/spec/AttributeValue.mockdata.js
+++ b/tests/spec/AttributeValue.mockdata.js
@@ -87,6 +87,15 @@ module.exports = {
     nothing1: { NULL: true }
   },
 
+  obj2_lowercase_: {
+    key1: { s: 'str' },
+    key1a: { ss: [ 'str1', 'str2', 'str3' ] },
+    key2: { n: '1' },
+    key2a: { ns: [ '1.1', '1.2', '1.3' ] },
+
+    nothing1: { null: true }
+  },
+
   obj3: {
     bin: new Buffer('Hi')
   },
@@ -95,7 +104,11 @@ module.exports = {
     bin: {B: new Buffer('Hi')}
   },
 
-  objInvalid_: { 
+  obj3_lowercase_: {
+    bin: {b: new Buffer('Hi')}
+  },
+
+  objInvalid_: {
     key1: { ABCD: 'str' }
   },
 

--- a/tests/spec/AttributeValue.spec.js
+++ b/tests/spec/AttributeValue.spec.js
@@ -8,8 +8,10 @@ describe("AttributeValue", function() {
   var obj1_ = mock.obj1_;
   var obj2 = mock.obj2;
   var obj2_ = mock.obj2_;
+  var obj2_lowercase_ = mock.obj2_lowercase_;
   var obj3 = mock.obj3;
   var obj3_ = mock.obj3_;
+  var obj3_lowercase_ = mock.obj3_lowercase_;
   var objInvalid_ = mock.objInvalid_;
   var singles = mock.singles;
   var singles_ = mock.singles_;
@@ -56,6 +58,13 @@ describe("AttributeValue", function() {
     expect(_.isEqual(util.unwrap(obj2_), obj2)).toBe(true);
 
     var binUnwrap = util.unwrap(obj3_).bin;
+    expect(bufferEqual(binUnwrap, obj3.bin)).toBe(true);
+  });
+
+  it("Unwrap lowercase type strings", function() {
+    expect(_.isEqual(util.unwrap(obj2_lowercase_), obj2)).toBe(true);
+
+    var binUnwrap = util.unwrap(obj3_lowercase_).bin;
     expect(bufferEqual(binUnwrap, obj3.bin)).toBe(true);
   });
 


### PR DESCRIPTION
Avoid failing with a "No data type (B, BS, N, NS, S, SS)" error when
type strings are not upper case.